### PR TITLE
Revert to calling autoStart from ready.

### DIFF
--- a/d2l-page-load-progress.html
+++ b/d2l-page-load-progress.html
@@ -51,7 +51,7 @@
 			}
 		},
 
-		attached: function() {
+		ready: function() {
 			if (this.autostart) {
 				this.start();
 			}


### PR DESCRIPTION
This avoids nav calling finish too early, which can result in the page-load-progress bar never finishing (ex. when opening a tool in a new tab).