### PR TITLE
Hidden attribute

### DIFF
--- a/d2l-page-load-progress.html
+++ b/d2l-page-load-progress.html
@@ -31,9 +31,6 @@ Polymer-based web component progress bar for the page load status
 			.d2l-page-load-progress-slow {
 				transition: transform 10s cubic-bezier(.16,1,.4,1);
 			}
-			.d2l-page-load-hidden {
-				display: none !important;
-			}
 		</style>
 		<div><div class="d2l-page-load-progress-bar"></div></div>
 	</template>
@@ -57,6 +54,15 @@ Polymer-based web component progress bar for the page load status
 				 * Whether the progress bar should automatically hide itself after loading.
 				 */
 				autohide: {
+					type: Boolean,
+					reflectToAttribute: true,
+					value: false
+				},
+
+				/**
+				 * Property for consumer-defined styling.
+				 */
+				hidden: {
 					type: Boolean,
 					reflectToAttribute: true,
 					value: false
@@ -134,11 +140,11 @@ Polymer-based web component progress bar for the page load status
 			},
 
 			_show: function() {
-				this.$$('.d2l-page-load-progress-bar').classList.remove('d2l-page-load-hidden');
+				this.hidden = false;
 			},
 
 			_hide: function() {
-				this.$$('.d2l-page-load-progress-bar').classList.add('d2l-page-load-hidden');
+				this.hidden = true;
 			}
 
 		});

--- a/test/d2l-page-load-progress.html
+++ b/test/d2l-page-load-progress.html
@@ -207,20 +207,20 @@
 
 				it('should not add hidden class when finishing if autohide not set', function() {
 					elem.finish();
-					expect(elem.$$('.d2l-page-load-progress-bar').classList.contains('d2l-page-load-hidden')).to.be.false;
+					expect(elem.hidden).to.be.false;
 				});
 
 				it('should add hidden class when finishing if autohide set', function() {
 					elem.autohide = true;
 					elem.finish();
-					expect(elem.$$('.d2l-page-load-progress-bar').classList.contains('d2l-page-load-hidden')).to.be.true;
+					expect(elem.hidden).to.be.true;
 				});
 
 				it('should remove hidden class on calling start', function() {
 					elem.autohide = true;
 					elem.finish();
 					elem.start();
-					expect(elem.$$('.d2l-page-load-progress-bar').classList.contains('d2l-page-load-hidden')).to.be.false;
+					expect(elem.hidden).to.be.false;
 				});
 			});
 


### PR DESCRIPTION
It appears that my previous PR did not work as I expected, so here's a PR that actually does what I was intending. If the previous functionality of auto-hiding the progress bar itself (but leaving its container visible) is a thing that peeps want, I can leave that in while still adding this stuff.